### PR TITLE
Add the ability to only display a user-specified number of todos

### DIFF
--- a/client/javascript/todos.js
+++ b/client/javascript/todos.js
@@ -25,6 +25,14 @@ get("/api/todos?contains=" + document.getElementById("contains").value, function
 })
 }
 
+function getAllTodosByLimit() {
+  console.log("Getting all the todos up to specified limit");
+
+get("/api/todos?limit=" + document.getElementById("limit").value, function (returned_json){
+  document.getElementById('jsonDump').innerHTML = returned_json;
+})
+}
+
 // gets todos from the api.
 // It adds the values of the various inputs to the requested URl to filter and order the returned todos.
 function getFilteredTodos() {

--- a/server/src/main/java/umm3601/Server.java
+++ b/server/src/main/java/umm3601/Server.java
@@ -85,7 +85,6 @@ public class Server {
   } catch (IOException e) {
     System.err.println("The server failed to load the todo data; shutting down.");
     e.printStackTrace(System.err);
-
     // Exit from Java
     System.exit(1);
   }

--- a/server/src/main/java/umm3601/todos/TodoDatabase.java
+++ b/server/src/main/java/umm3601/todos/TodoDatabase.java
@@ -5,6 +5,8 @@ import java.io.InputStreamReader;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.lang.Math;
+import java.lang.NumberFormatException;
 
 import com.google.gson.Gson;
 
@@ -38,7 +40,7 @@ public class TodoDatabase {
 
     // Filter by status if defined
     if (queryParams.containsKey("status")) {
-      String targetStatus = queryParams.get("status").get(0);
+      String targetStatus = queryParams.get("stimport java.exceNumberFormatException;atus").get(0);
       Boolean bTargetStatus;
 
       if (targetStatus.equals("complete")) {
@@ -52,6 +54,19 @@ public class TodoDatabase {
     if (queryParams.containsKey("contains")) {
       String targetBodyText = queryParams.get("contains").get(0);
       filteredTodos = filterTodosByBody(filteredTodos, targetBodyText);
+    }
+    // Filter number of todos if defined
+    if (queryParams.containsKey("limit")) {
+      String stringLimit = queryParams.get("limit").get(0);
+      /**
+       * May throw NumberFormatException
+       */
+      try{
+      int intLimit = Integer.parseInt(stringLimit);
+      filteredTodos = filterTodosByLimit(filteredTodos, intLimit);
+      }catch (NumberFormatException e) {
+      System.err.println("The string value cannot be parsed.");
+      }
     }
 
     return filteredTodos;
@@ -77,5 +92,21 @@ public class TodoDatabase {
    */
   public Todo[] filterTodosByStatus(Todo[] todos, Boolean targetStatus) {
     return Arrays.stream(todos).filter(x -> x.status == (targetStatus)).toArray(Todo[]::new);
+  }
+
+  /**
+   * Get an arra of all todos capped at some user input limit
+   * 
+   * @param todos list of todos to cap the number displayed
+   * @param intLimit  the user-specified number of todos to display
+   * @return an array of all the todos from the given list that fit within the limit
+   */
+  public Todo[] filterTodosByLimit(Todo[] todos, int intLimit) {
+    //making sure that the array stays within max bounds
+    if(intLimit > 300) intLimit = 300;
+    if(intLimit < -300) intLimit = 300;
+    if(intLimit < 0) intLimit = Math.abs(intLimit);
+    Todo[] limitedTodo = Arrays.copyOfRange(todos, 0, intLimit);
+    return limitedTodo;
   }
 }

--- a/server/src/test/java/umm3601/todos/FilterTodosByLimit.java
+++ b/server/src/test/java/umm3601/todos/FilterTodosByLimit.java
@@ -1,0 +1,30 @@
+package umm3601.todos;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Testing umm3601.todos.TodoDatabase filterTodosByStatus and litsTodos
+ * with _status_ parameters
+ */
+public class FilterTodosByLimit {
+
+    @Test
+    public void filterTodosByLimit() throws IOException {
+    TodoDatabase tdb = new TodoDatabase("/todos.json");
+    Todo[] allTodos = tdb.listTodos(new HashMap<>());
+
+    Todo[] todoLimit10 = tdb.filterTodosByLimit(allTodos, 10);
+    assertEquals(10, todoLimit10.length, "Incorrect number of todos output");
+
+    Todo[] todoLimit5 = tdb.filterTodosByLimit(allTodos, 5);
+    assertEquals(5, todoLimit5.length, "Incorrect number of todos output"); 
+    }
+}


### PR DESCRIPTION
Also added two tests for this function, that make sure the number of todos displayed matches the user input.

When limiting the number of todos displayed, if an invalid argument is entered, an error message is displayed in the terminal, and whatever json was displayed remains on-screen.

Tests are currently passing and all prior functionality remains intact.