### PR TITLE
Create filter todos by owner functionality

### DIFF
--- a/client/javascript/todos.js
+++ b/client/javascript/todos.js
@@ -33,6 +33,14 @@ get("/api/todos?limit=" + document.getElementById("limit").value, function (retu
 })
 }
 
+function getAllTodosByOwner() {
+  console.log("Getting all the todos with the specified owner");
+
+get("/api/todos?owner=" + document.getElementById("owner").value, function (returned_json){
+  document.getElementById('jsonDump').innerHTML = returned_json;
+})
+}
+
 // gets todos from the api.
 // It adds the values of the various inputs to the requested URl to filter and order the returned todos.
 function getFilteredTodos() {

--- a/server/src/main/java/umm3601/todos/TodoDatabase.java
+++ b/server/src/main/java/umm3601/todos/TodoDatabase.java
@@ -55,6 +55,11 @@ public class TodoDatabase {
       String targetBodyText = queryParams.get("contains").get(0);
       filteredTodos = filterTodosByBody(filteredTodos, targetBodyText);
     }
+    // Filter by owner if defined
+    if (queryParams.containsKey("owner")) {
+      String targetOwner = queryParams.get("owner").get(0);
+      filteredTodos = filterTodosByOwner(filteredTodos, targetOwner);
+    }
     // Filter number of todos if defined
     if (queryParams.containsKey("limit")) {
       String stringLimit = queryParams.get("limit").get(0);
@@ -92,6 +97,16 @@ public class TodoDatabase {
    */
   public Todo[] filterTodosByStatus(Todo[] todos, Boolean targetStatus) {
     return Arrays.stream(todos).filter(x -> x.status == (targetStatus)).toArray(Todo[]::new);
+  }
+
+  /**
+   * Get an array of all todos with target owner
+   * @param todos
+   * @param targetOwner
+   * @return an array of all todos with the desired owner
+   */
+  public Todo[] filterTodosByOwner(Todo[] todos, String targetOwner) {
+    return Arrays.stream(todos).filter(x -> x.owner.equalsIgnoreCase((targetOwner.replaceAll(" ", "")))).toArray(Todo[]::new);
   }
 
   /**

--- a/server/src/test/java/umm3601/todos/FilterTodosByOwner.java
+++ b/server/src/test/java/umm3601/todos/FilterTodosByOwner.java
@@ -1,0 +1,30 @@
+package umm3601.todos;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Testing umm3601.todos.TodoDatabase filterTodosByStatus and litsTodos
+ * with _status_ parameters
+ */
+public class FilterTodosByOwner {
+
+    @Test
+    public void filterTodosByOwner() throws IOException {
+    TodoDatabase tdb = new TodoDatabase("/todos.json");
+    Todo[] allTodos = tdb.listTodos(new HashMap<>());
+
+    Todo[] todoLimit10 = tdb.filterTodosByOwner(allTodos, " Barry     ");
+    assertEquals(51, todoLimit10.length, "Incorrect number of todos output");
+
+    Todo[] todoLimit5 = tdb.filterTodosByOwner(allTodos, "roberta");
+    assertEquals(46, todoLimit5.length, "Incorrect number of todos output"); 
+    }
+}


### PR DESCRIPTION
Owner filtration now exists and ignores caps and white space in user input.
Added testing for said functionality, which currently passes and has full coverage. 
Created /api/todos?owner= endpoint so that the owner filter works.