### PR TITLE
Implement filtering todos by category and fixed copy-paste error

### DIFF
--- a/client/javascript/todos.js
+++ b/client/javascript/todos.js
@@ -41,6 +41,14 @@ get("/api/todos?owner=" + document.getElementById("owner").value, function (retu
 })
 }
 
+function getAllTodosByCategory() {
+  console.log("Getting all the todos with the specified category");
+
+get("/api/todos?category=" + document.getElementById("category").value, function (returned_json) {
+  document.getElementById('jsonDump').innerHTML = returned_json;
+})
+}
+
 // gets todos from the api.
 // It adds the values of the various inputs to the requested URl to filter and order the returned todos.
 function getFilteredTodos() {

--- a/server/src/main/java/umm3601/todos/TodoDatabase.java
+++ b/server/src/main/java/umm3601/todos/TodoDatabase.java
@@ -60,6 +60,11 @@ public class TodoDatabase {
       String targetOwner = queryParams.get("owner").get(0);
       filteredTodos = filterTodosByOwner(filteredTodos, targetOwner);
     }
+    // Filter by category if defined
+    if(queryParams.containsKey("category")) {
+      String targetCategory = queryParams.get("category").get(0);
+      filteredTodos = filterTodosByCategory(filteredTodos, targetCategory);
+    }
     // Filter number of todos if defined
     if (queryParams.containsKey("limit")) {
       String stringLimit = queryParams.get("limit").get(0);
@@ -107,6 +112,16 @@ public class TodoDatabase {
    */
   public Todo[] filterTodosByOwner(Todo[] todos, String targetOwner) {
     return Arrays.stream(todos).filter(x -> x.owner.equalsIgnoreCase((targetOwner.replaceAll(" ", "")))).toArray(Todo[]::new);
+  }
+
+  /**
+   * Get an array of all todos with target category
+   * @param todos list of all todos to be filtered by category
+   * @param targetCategory desired category
+   * @return an array of all todos with the desired category
+   */
+  public Todo[] filterTodosByCategory(Todo[] todos, String targetCategory) {
+    return Arrays.stream(todos).filter(x -> x.category.replaceAll(" ", "").equalsIgnoreCase((targetCategory.replaceAll(" ", "")))).toArray(Todo[]::new);
   }
 
   /**

--- a/server/src/test/java/umm3601/todos/FilterTodosByBody.java
+++ b/server/src/test/java/umm3601/todos/FilterTodosByBody.java
@@ -23,8 +23,5 @@ public class FilterTodosByBody {
     //note: nostrud proident actually occurs twice, but one instance has a capitalized n, which contains treats as a different char sequence
     Todo[] temporBody = tdb.filterTodosByBody(allTodos, "nostrud proident");
     assertEquals(1, temporBody.length, "Incorrect number of todos with nostrud proident in body");
-
-    Todo[] statusIncomplete = tdb.filterTodosByBody(allTodos, "in cillum");
-    assertEquals(5, statusIncomplete.length, "Incorrect number of todos with in cillum in body"); 
     }
 }

--- a/server/src/test/java/umm3601/todos/FilterTodosByCategory.java
+++ b/server/src/test/java/umm3601/todos/FilterTodosByCategory.java
@@ -1,0 +1,29 @@
+package umm3601.todos;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Testing umm3601.todos.TodoDatabase filterTodosByCategory
+ */
+public class FilterTodosByCategory {
+
+    @Test
+    public void filterTodosByCategory() throws IOException {
+    TodoDatabase tdb = new TodoDatabase("/todos.json");
+    Todo[] allTodos = tdb.listTodos(new HashMap<>());
+
+    Todo[] hwCategory = tdb.filterTodosByCategory(allTodos, "homework");
+    assertEquals(79, hwCategory.length, "Incorrect number of todos with homework as category");
+
+    Todo[] vgCategory = tdb.filterTodosByCategory(allTodos, "videogames");
+    assertEquals(71, vgCategory.length, "Incorrect number of todos with video games as category"); 
+    }
+}

--- a/server/src/test/java/umm3601/todos/TodoControllerSpec.java
+++ b/server/src/test/java/umm3601/todos/TodoControllerSpec.java
@@ -71,6 +71,23 @@ public class TodoControllerSpec {
   }
 
   @Test
+  public void GET_to_request_category_video_games_todos() throws IOException {
+
+    Map<String, List<String>> queryParams = new HashMap<>();
+    queryParams.put("category", Arrays.asList(new String[] { "video games" }));
+
+    when(ctx.queryParamMap()).thenReturn(queryParams);
+    todoController.getTodos(ctx);
+
+    // Confirm that all the todos passed to `json` have owner name Barry.
+    ArgumentCaptor<Todo[]> argument = ArgumentCaptor.forClass(Todo[].class);
+    verify(ctx).json(argument.capture());
+    for (Todo todo : argument.getValue()) {
+      assertEquals("video games", todo.category);
+    }
+  }
+
+  @Test
   public void GET_to_request_status_complete_todos() throws IOException {
 
     Map<String, List<String>> queryParams = new HashMap<>();
@@ -217,7 +234,9 @@ public void GET_to_request_todo_with_limit_negative_10() throws IOException {
     queryParams.put("owner", Arrays.asList(new String[] { "Barry" }));
     queryParams.put("contains", Arrays.asList(new String[] { "nisi" }));
     queryParams.put("status", Arrays.asList(new String[] { "complete" }));
+    queryParams.put("category", Arrays.asList(new String[] { "video games" }));
     queryParams.put("limit", Arrays.asList(new String[] { "rand" }));
+    
 
     when(ctx.queryParamMap()).thenReturn(queryParams);
     todoController.getTodos(ctx);
@@ -230,6 +249,7 @@ public void GET_to_request_todo_with_limit_negative_10() throws IOException {
       assertEquals("Barry", todo.owner);
       assertEquals(true, todo.status);
       assertEquals(true, todo.body.contains("nisi"));
+      assertEquals("video games", todo.category);
       //array should have a length that is <= to the limit, depending on whether it has enough entries
       assertEquals(argument.getValue().length <= rand, true);
     }


### PR DESCRIPTION
Allows users to enter in a category on the website in the category box, and restrict todo search results to said category.

Added testing for filterTodosByCategory where the filtered todos are checked to make sure they are of the expected length.

Added testing for TodoControllerSpec as well.

All tests are passing and coverage remains at 100% for all but the server.

Closes #7